### PR TITLE
feat: Demo: Add employee search and salary range filter (#1)

### DIFF
--- a/.specify/specs/001-demo-add-employee-search-and-salary-range-filter/plan.md
+++ b/.specify/specs/001-demo-add-employee-search-and-salary-range-filter/plan.md
@@ -1,0 +1,129 @@
+# Implementation Plan: Demo: Add employee search and salary range filter
+
+> Spec: [spec.md](./spec.md)
+> Status: Draft
+
+## Technical Approach
+
+Implement dashboard filtering as server-rendered GET query parameters so the page can preserve filter state across refreshes and links without introducing client-side state management. The request layer will parse and validate a `search`, `minSalary`, and `maxSalary` filter object, pass that object into the existing SQLite-backed employee listing flow, and render the filtered roster plus a visible active-filter summary and clear action.
+
+To keep existing CRUD behavior stable, the dashboard should continue to use the current POST create/update/delete routes, but those forms should preserve the current filtered return URL so users stay in context after a mutation. The implementation should keep top-level payroll summary cards on the existing full-roster dataset unless the open question in the spec is clarified otherwise, and only the roster/editing surfaces should reflect the active filters.
+
+## Technology Stack
+
+- **Framework:** Existing Express server-rendered application (`src/server.js`)
+- **Database:** Existing SQLite database via `better-sqlite3`
+- **Libraries:** Existing runtime dependencies; add a lightweight HTTP test dependency only if needed (for example `supertest`) alongside Node's built-in `node:test`
+- **Patterns:** Parameterized SQL filtering, server-side form/query parsing, renderer-driven HTML composition, progressive enhancement through GET filters
+
+## Architecture
+
+### Components
+
+1. **Dashboard filter parsing (`src/server.js` or a small helper module)** - Normalize query params, trim search input, validate salary bounds, and produce a safe filter state plus any non-fatal validation feedback.
+2. **Filtered employee query (`src/db.js`)** - Extend employee listing to accept optional search and salary constraints using parameterized SQL while preserving the current default unfiltered behavior.
+3. **Dashboard renderer updates (`src/render.js`)** - Render filter controls, active-filter summary, clear action, empty state, and filter-preserving CRUD form actions.
+4. **Presentation styling (`src/public/styles.css`)** - Add layout and visual treatment for the filter bar, filter chips/summary, validation guidance, and empty results state.
+5. **Regression and feature tests (`test/`)** - Verify filtering, validation, empty state, clear action, and unchanged CRUD flows with automated coverage.
+
+### Data Model
+
+No database schema changes are required.
+
+Add an application-level dashboard filter state object passed from the request layer to the renderer, for example:
+
+```js
+{
+  search: '',
+  minSalary: '',
+  maxSalary: '',
+  applied: {
+    search: null,
+    minSalary: null,
+    maxSalary: null,
+  },
+  hasActiveFilters: false,
+  validationMessage: ''
+}
+```
+
+Implementation should also preserve a safe local return path/query string for POST actions so create/update/delete redirects can return users to the filtered dashboard view.
+
+### API Contracts
+
+No new endpoints are required.
+
+#### `GET /`
+
+Support optional query parameters:
+
+- `search` - case-insensitive partial match against employee name and title
+- `minSalary` - inclusive lower salary bound
+- `maxSalary` - inclusive upper salary bound
+- `message` - existing flash-style banner message
+
+Behavior:
+
+- Blank filter values behave as unset.
+- Invalid salary inputs should not crash the page.
+- If `minSalary > maxSalary`, render a helpful validation message and avoid applying an invalid salary range.
+- The response should keep form inputs populated with the submitted values.
+
+#### Existing POST routes
+
+- `POST /employees`
+- `POST /employees/:id/update`
+- `POST /employees/:id/delete`
+
+Keep existing payloads and side effects unchanged, but add a validated hidden return target (or equivalent query-string preservation) so redirects can land back on the current filtered dashboard state.
+
+## File Changes
+
+### New Files
+- `.specify/specs/001-demo-add-employee-search-and-salary-range-filter/plan.md` - Technical implementation plan for this feature
+- `test/dashboard.test.js` - End-to-end server-rendering tests for filters, validation, empty states, clear action, and CRUD regressions
+- `src/dashboardFilters.js` - Small helper module for parsing/serializing dashboard filter state and validating safe return URLs (recommended if server logic starts to grow)
+
+### Modified Files
+- `package.json` - Add a `test` script and any minimal dev dependency required for HTTP-level tests
+- `src/server.js` - Parse filter query params, fetch filtered and unfiltered datasets as needed, preserve return-to state on redirects, and pass filter metadata into the renderer
+- `src/db.js` - Extend `listEmployees` to support optional parameterized search/min/max salary filters; optionally allow a configurable DB path for isolated tests
+- `src/render.js` - Add filter form, active-filter summary, clear button, no-results state, and hidden return state in CRUD forms
+- `src/public/styles.css` - Style the new filter controls, active-filter UI, validation message, and empty-state components
+
+## Integration Points
+
+- **Request → data layer:** `src/server.js` will translate `req.query` into a validated filter object and call `listEmployees(filters)`.
+- **Data layer → renderer:** The server should pass both the filtered employee list and the full employee roster to the renderer so manager dropdowns still include all employees even when the visible roster is filtered.
+- **Renderer → existing CRUD routes:** Create/update/delete forms should include a safe hidden return target so redirects preserve the current dashboard context.
+- **Testing → database setup:** Tests should run against an isolated SQLite file or temporary database path to avoid mutating `data/payroll.sqlite` during CI.
+
+## Testing Strategy
+
+- Unit tests for filter parsing/validation rules if a dedicated helper module is introduced
+- Integration tests for `GET /` covering:
+  - name search
+  - title search
+  - min-only salary filtering
+  - max-only salary filtering
+  - inclusive min/max range filtering
+  - invalid salary inputs and `minSalary > maxSalary`
+  - active-filter summary and clear action rendering
+  - empty-state rendering when no employees match
+- Regression tests for create, update, and delete flows to ensure they still succeed and can preserve a filtered return view
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Filtered datasets accidentally restrict manager dropdown choices | Pass the full employee roster separately for manager option rendering while only filtering the visible roster/cards |
+| Invalid or contradictory salary inputs create confusing behavior | Centralize validation, keep entered values visible, and render a clear guidance message instead of throwing or breaking rendering |
+| Query-string preservation introduces open redirect or unsafe navigation behavior | Only allow local dashboard return paths and validate/sanitize any hidden return target before redirecting |
+| Test coverage is hard to add because the SQLite path is currently fixed | Make the DB path configurable for tests or initialize the database from a temporary file during test setup |
+| Summary card behavior is ambiguous because the spec leaves it open | Preserve current full-roster summary behavior by default and call out the assumption for reviewer confirmation |
+
+## Dependencies
+
+- Existing runtime dependencies are sufficient for the feature itself
+- A minimal test dependency may be added if HTTP-level assertions are cumbersome with built-in tools alone
+- Reviewer confirmation on the spec's open question: whether summary cards should remain global or reflect the filtered employee subset

--- a/.specify/specs/001-demo-add-employee-search-and-salary-range-filter/spec.md
+++ b/.specify/specs/001-demo-add-employee-search-and-salary-range-filter/spec.md
@@ -1,0 +1,70 @@
+# Feature: Demo: Add employee search and salary range filter
+
+> Issue: #1
+> Status: Draft
+
+## Problem Statement
+
+The payroll dashboard currently lists all employees in a single unfiltered view. For demos, that makes it harder to quickly highlight a specific employee, role, or compensation band without manually scanning the full roster.
+
+Adding employee search and salary range filters will make the dashboard easier to present, easier to navigate, and more useful for focused conversations about payroll data, while preserving the existing create, update, and delete workflows that the demo already relies on.
+
+## User Stories
+
+1. As a demo presenter, I want to search employees by name or job title, so that I can quickly find the people I want to discuss.
+2. As a demo presenter, I want to filter employees by minimum and maximum salary, so that I can focus on a specific compensation band.
+3. As a payroll administrator, I want the dashboard to clearly show which filters are active and give me a single way to clear them, so that I can understand the current view and reset it quickly.
+4. As an existing user of the payroll dashboard, I want employee create, update, and delete behavior to remain unchanged, so that adding filters does not disrupt current workflows.
+
+## Functional Requirements
+
+### Must Have
+
+- [ ] Support searching employees by employee name or title from the payroll dashboard.
+- [ ] Apply search matching in a user-friendly way so partial matches can surface relevant employees.
+- [ ] Support filtering employees by minimum salary.
+- [ ] Support filtering employees by maximum salary.
+- [ ] Treat salary range boundaries as inclusive when filtering matching employees.
+- [ ] Validate salary filter inputs so invalid values do not break the page experience.
+- [ ] Display the currently active search and salary filters in a visible summary area on the dashboard.
+- [ ] Provide a clear action that removes all active filters and returns the dashboard to its default unfiltered state.
+- [ ] Update the employee listing views on the dashboard to reflect the active search and salary filters.
+- [ ] Preserve existing employee create, update, and delete capabilities for employees that remain visible in the current filtered view.
+- [ ] Preserve the existing unfiltered experience when no search term or salary filters are applied.
+- [ ] Show a clear empty state when no employees match the active filters.
+
+### Should Have
+
+- [ ] Keep filter inputs populated with the currently applied values so users can understand and refine the current view.
+- [ ] Make the active filter summary easy to scan during a live demo.
+- [ ] Provide helpful validation or guidance when the minimum salary is greater than the maximum salary.
+
+### Nice to Have
+
+- [ ] Preserve the current filtered view in a shareable or refresh-safe way.
+- [ ] Offer individual removal of active filters in addition to the clear-all action.
+
+## Acceptance Criteria
+
+- [ ] Verify that entering a search term matching an employee name narrows the dashboard to matching employees only.
+- [ ] Verify that entering a search term matching an employee title narrows the dashboard to matching employees only.
+- [ ] Verify that applying only a minimum salary shows employees whose salaries are greater than or equal to that value.
+- [ ] Verify that applying only a maximum salary shows employees whose salaries are less than or equal to that value.
+- [ ] Verify that applying both minimum and maximum salary shows only employees within the inclusive range.
+- [ ] Verify that the dashboard visibly shows the active search term and salary filters after they are applied.
+- [ ] Verify that the clear action removes all filters and restores the default employee view.
+- [ ] Verify that the dashboard shows a clear no-results state when filters match no employees.
+- [ ] Verify that employee add, edit, and delete flows continue to work as they do today.
+- [ ] Verify that invalid salary filter inputs are handled gracefully without breaking the dashboard.
+
+## Out of Scope
+
+- Adding new employee data fields beyond the existing name, title, salary, manager, and address fields.
+- Changing employee create, update, or delete rules beyond what is necessary to keep them working with filtered views.
+- Advanced filtering beyond the requested search term plus minimum and maximum salary.
+- Sorting, pagination, export, or bulk actions.
+- Authentication, authorization, or role-based access changes.
+
+## Open Questions
+
+1. Should the summary cards at the top of the dashboard reflect the filtered employee set, or should they continue to show metrics for the full payroll roster regardless of active filters?

--- a/.specify/specs/001-demo-add-employee-search-and-salary-range-filter/tasks.md
+++ b/.specify/specs/001-demo-add-employee-search-and-salary-range-filter/tasks.md
@@ -1,0 +1,72 @@
+# Task Breakdown: Demo: Add employee search and salary range filter
+
+> Spec: [spec.md](./spec.md)
+> Plan: [plan.md](./plan.md)
+> Status: Ready for Implementation
+
+## Prerequisites
+
+- [ ] Confirm the plan assumption that summary cards remain based on the full employee roster unless reviewers explicitly choose filtered summaries.
+
+## Phase 1: Foundation
+
+### Task 1.1: Extract dashboard filter parsing and return-state helpers
+- **File(s):** `src/dashboardFilters.js`, `src/server.js`
+- **Description:** Introduce a small helper for normalizing `search`, `minSalary`, and `maxSalary`, validating contradictory ranges, and safely serializing a local dashboard return target so server logic stays focused and reusable.
+- **Depends on:** None
+- **Parallel:** No
+
+### Task 1.2: Establish isolated dashboard test coverage [P]
+- **File(s):** `package.json`, `src/db.js`, `test/dashboard.test.js`
+- **Description:** Add a `test` script plus a lightweight integration harness that can run the Express app against an isolated SQLite database path instead of mutating `data/payroll.sqlite`.
+- **Depends on:** None
+- **Parallel:** Yes (can run with 1.1)
+
+## Phase 2: Filtered Data Flow
+
+### Task 2.1: Add parameterized filter-aware employee queries
+- **File(s):** `src/db.js`
+- **Description:** Extend employee listing access to support case-insensitive partial name/title matching and inclusive min/max salary filtering while preserving the current unfiltered default query.
+- **Depends on:** Task 1.1
+- **Parallel:** No
+
+### Task 2.2: Pass filtered and full-roster data through request handlers
+- **File(s):** `src/server.js`, `src/db.js`
+- **Description:** Use the parsed filter state in `GET /` and `GET /api/employees`, keep summary cards on full-roster data by default, and pass both the filtered roster and full employee list where the renderer needs unfiltered manager options.
+- **Depends on:** Task 1.1, Task 2.1
+- **Parallel:** No
+
+## Phase 3: Dashboard UI
+
+### Task 3.1: Render filter controls, active state, and empty results
+- **File(s):** `src/render.js`
+- **Description:** Add a GET-based filter form, keep submitted values populated, show active-filter summary and validation guidance, provide a clear-all action, and render a no-results state when the filtered roster is empty.
+- **Depends on:** Task 2.2
+- **Parallel:** No
+
+### Task 3.2: Style the filter experience and empty states [P]
+- **File(s):** `src/public/styles.css`
+- **Description:** Add layout and presentation rules for the filter bar, active-filter summary, validation banner, and empty-state components so the new controls remain easy to scan during demos across desktop and mobile layouts.
+- **Depends on:** Task 2.2
+- **Parallel:** Yes (can run with 3.1)
+
+## Phase 4: CRUD Continuity & Verification
+
+### Task 4.1: Preserve safe filtered return behavior for CRUD actions
+- **File(s):** `src/server.js`, `src/dashboardFilters.js`, `src/render.js`
+- **Description:** Add validated hidden return targets (or equivalent query preservation) to create, update, and delete flows so successful mutations land back on the current filtered dashboard without introducing unsafe redirects.
+- **Depends on:** Task 1.1, Task 3.1
+- **Parallel:** No
+
+### Task 4.2: Add regression coverage for filter behavior and CRUD continuity
+- **File(s):** `package.json`, `src/db.js`, `test/dashboard.test.js`
+- **Description:** Verify name search, title search, min-only and max-only filtering, inclusive salary ranges, invalid salary handling, active-filter rendering, clear-all behavior, empty states, and unchanged CRUD workflows with filtered return context.
+- **Depends on:** Task 1.2, Task 2.2, Task 3.1, Task 3.2, Task 4.1
+- **Parallel:** No
+
+## Checkpoints
+
+- [ ] After Phase 1: Filter helpers and isolated test setup are in place
+- [ ] After Phase 2: Backend filtering works for dashboard and API handlers without changing summary defaults
+- [ ] After Phase 3: UI clearly shows filters, validation, and no-results feedback
+- [ ] After Phase 4: CRUD flows preserve dashboard context and all automated tests pass

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,5 @@
 - Database module: `src/db.js`, storing local data in `data/payroll.sqlite`.
 - Renderer and styling: `src/render.js` and `src/public/styles.css`.
 - The database seeds 6 employee records on first run.
+- Manager `<select>` options in `src/render.js` are derived from the employee collection passed into `renderDashboard`, so filtered views need separate access to the full roster to avoid hiding valid manager choices.
+- The SQLite path is currently fixed inside `src/db.js`, so isolated automated tests may need that module to support a configurable test database path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,4 +26,6 @@
 - Renderer and styling: `src/render.js` and `src/public/styles.css`.
 - The database seeds 6 employee records on first run.
 - Manager `<select>` options in `src/render.js` are derived from the employee collection passed into `renderDashboard`, so filtered views need separate access to the full roster to avoid hiding valid manager choices.
-- The SQLite path is currently fixed inside `src/db.js`, so isolated automated tests may need that module to support a configurable test database path.
+- Dashboard filters now live in `src/dashboardFilters.js`; the helper normalizes `search`, `minSalary`, and `maxSalary`, preserves safe return-to state for CRUD redirects, and rejects non-dashboard redirect targets.
+- `src/db.js` supports a `PAYROLL_DB_PATH` environment override and exports `closeDatabase()` so integration tests can run against isolated SQLite files without touching `data/payroll.sqlite`.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,9 @@
 - `PORT=12000 npm start`
 - `curl http://127.0.0.1:12000/health`
 
+## Workflow notes
+- The expected spec artifacts may be incomplete on long-running step chains; issue #1 reached the task step without a `plan.md` file in `.specify/specs/001-demo-add-employee-search-and-salary-range-filter/`, so verify the spec directory contents before assuming prior-step outputs exist.
+
 ## Payroll app example
 - Express + SQLite payroll dashboard lives in `src/`.
 - Entry point: `src/server.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,32 @@
       "dependencies": {
         "better-sqlite3": "^11.8.1",
         "express": "^4.21.2"
+      },
+      "devDependencies": {
+        "supertest": "^7.2.2"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/accepts": {
@@ -29,6 +55,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/base64-js": {
@@ -174,6 +214,29 @@
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "license": "ISC"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "0.5.4",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -210,6 +273,13 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -243,6 +313,16 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -269,6 +349,17 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dunder-proto": {
@@ -334,6 +425,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -409,6 +516,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -431,6 +545,41 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -526,6 +675,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -1144,6 +1309,90 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/superagent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/superagent/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/superagent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/tar-fs": {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,14 @@
   "main": "src/server.js",
   "scripts": {
     "start": "node src/server.js",
-    "dev": "node src/server.js"
+    "dev": "node src/server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "better-sqlite3": "^11.8.1",
     "express": "^4.21.2"
+  },
+  "devDependencies": {
+    "supertest": "^7.2.2"
   }
 }

--- a/src/dashboardFilters.js
+++ b/src/dashboardFilters.js
@@ -1,0 +1,137 @@
+const DASHBOARD_PATH = '/';
+const BASE_URL = 'http://dashboard.local';
+
+function normalizeValue(value) {
+  if (Array.isArray(value)) {
+    return normalizeValue(value[0]);
+  }
+
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function parseSalaryInput(value) {
+  const raw = normalizeValue(value);
+
+  if (!raw) {
+    return { raw: '', value: null, invalid: false };
+  }
+
+  if (!/^\d+$/.test(raw)) {
+    return { raw, value: null, invalid: true };
+  }
+
+  return { raw, value: Number.parseInt(raw, 10), invalid: false };
+}
+
+function buildDashboardPath({ search = '', minSalary = '', maxSalary = '', message = '' } = {}) {
+  const url = new URL(DASHBOARD_PATH, BASE_URL);
+
+  if (search) {
+    url.searchParams.set('search', search);
+  }
+
+  if (minSalary) {
+    url.searchParams.set('minSalary', minSalary);
+  }
+
+  if (maxSalary) {
+    url.searchParams.set('maxSalary', maxSalary);
+  }
+
+  if (message) {
+    url.searchParams.set('message', message);
+  }
+
+  const query = url.searchParams.toString();
+  return query ? `${url.pathname}?${query}` : url.pathname;
+}
+
+function parseDashboardFilters(query = {}) {
+  const search = normalizeValue(query.search);
+  const minSalary = parseSalaryInput(query.minSalary);
+  const maxSalary = parseSalaryInput(query.maxSalary);
+
+  let validationMessage = '';
+  let appliedMinSalary = minSalary.value;
+  let appliedMaxSalary = maxSalary.value;
+
+  if (minSalary.invalid || maxSalary.invalid) {
+    validationMessage = 'Salary filters must be whole numbers or left blank.';
+
+    if (minSalary.invalid) {
+      appliedMinSalary = null;
+    }
+
+    if (maxSalary.invalid) {
+      appliedMaxSalary = null;
+    }
+  }
+
+  if (!validationMessage && appliedMinSalary !== null && appliedMaxSalary !== null && appliedMinSalary > appliedMaxSalary) {
+    validationMessage = 'Minimum salary cannot be greater than maximum salary.';
+    appliedMinSalary = null;
+    appliedMaxSalary = null;
+  }
+
+  const appliedSearch = search || null;
+  const hasSubmittedValues = Boolean(search || minSalary.raw || maxSalary.raw);
+  const hasActiveFilters = Boolean(appliedSearch || appliedMinSalary !== null || appliedMaxSalary !== null);
+
+  return {
+    search,
+    minSalary: minSalary.raw,
+    maxSalary: maxSalary.raw,
+    applied: {
+      search: appliedSearch,
+      minSalary: appliedMinSalary,
+      maxSalary: appliedMaxSalary,
+    },
+    hasSubmittedValues,
+    hasActiveFilters,
+    validationMessage,
+    returnTo: buildDashboardPath({ search, minSalary: minSalary.raw, maxSalary: maxSalary.raw }),
+  };
+}
+
+function sanitizeReturnTo(value) {
+  const raw = normalizeValue(value);
+
+  if (!raw) {
+    return DASHBOARD_PATH;
+  }
+
+  try {
+    const url = new URL(raw, BASE_URL);
+
+    if (url.origin !== BASE_URL || url.pathname !== DASHBOARD_PATH) {
+      return DASHBOARD_PATH;
+    }
+
+    return buildDashboardPath({
+      search: normalizeValue(url.searchParams.get('search')),
+      minSalary: normalizeValue(url.searchParams.get('minSalary')),
+      maxSalary: normalizeValue(url.searchParams.get('maxSalary')),
+    });
+  } catch {
+    return DASHBOARD_PATH;
+  }
+}
+
+function appendMessageToReturnTo(returnTo, message) {
+  const safeReturnTo = sanitizeReturnTo(returnTo);
+  const url = new URL(safeReturnTo, BASE_URL);
+
+  if (message) {
+    url.searchParams.set('message', message);
+  }
+
+  const query = url.searchParams.toString();
+  return query ? `${url.pathname}?${query}` : url.pathname;
+}
+
+module.exports = {
+  appendMessageToReturnTo,
+  buildDashboardPath,
+  parseDashboardFilters,
+  sanitizeReturnTo,
+};

--- a/src/db.js
+++ b/src/db.js
@@ -2,10 +2,10 @@ const fs = require('fs');
 const path = require('path');
 const Database = require('better-sqlite3');
 
-const dataDirectory = path.join(__dirname, '..', 'data');
-const databasePath = path.join(dataDirectory, 'payroll.sqlite');
+const defaultDatabasePath = path.join(__dirname, '..', 'data', 'payroll.sqlite');
+const databasePath = process.env.PAYROLL_DB_PATH || defaultDatabasePath;
 
-fs.mkdirSync(dataDirectory, { recursive: true });
+fs.mkdirSync(path.dirname(databasePath), { recursive: true });
 
 const db = new Database(databasePath);
 
@@ -86,7 +86,7 @@ if (countEmployeesStatement.get().count === 0) {
   seed();
 }
 
-const listEmployeesStatement = db.prepare(`
+const baseEmployeeSelect = `
   SELECT
     employee.id,
     employee.name,
@@ -98,8 +98,7 @@ const listEmployeesStatement = db.prepare(`
     employee.updated_at AS updatedAt
   FROM employees AS employee
   LEFT JOIN employees AS manager ON manager.id = employee.manager_id
-  ORDER BY employee.name COLLATE NOCASE
-`);
+`;
 
 const summaryStatement = db.prepare(`
   SELECT
@@ -130,8 +129,40 @@ const getEmployeeStatement = db.prepare(`
   WHERE id = ?
 `);
 
-function listEmployees() {
-  return listEmployeesStatement.all();
+function escapeLikePattern(value) {
+  return value.replace(/([\\%_])/g, '\\$1');
+}
+
+function listEmployees(filters = {}) {
+  const conditions = [];
+  const params = {};
+
+  if (filters.search) {
+    conditions.push(`(
+      employee.name LIKE @search ESCAPE '\\' COLLATE NOCASE
+      OR employee.title LIKE @search ESCAPE '\\' COLLATE NOCASE
+    )`);
+    params.search = `%${escapeLikePattern(filters.search)}%`;
+  }
+
+  if (filters.minSalary !== null && filters.minSalary !== undefined) {
+    conditions.push('employee.salary >= @minSalary');
+    params.minSalary = filters.minSalary;
+  }
+
+  if (filters.maxSalary !== null && filters.maxSalary !== undefined) {
+    conditions.push('employee.salary <= @maxSalary');
+    params.maxSalary = filters.maxSalary;
+  }
+
+  const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+  const statement = db.prepare(`
+    ${baseEmployeeSelect}
+    ${whereClause}
+    ORDER BY employee.name COLLATE NOCASE
+  `);
+
+  return statement.all(params);
 }
 
 function getSummary() {
@@ -161,11 +192,17 @@ function deleteEmployee(id) {
   return employee;
 }
 
+function closeDatabase() {
+  db.close();
+}
+
 module.exports = {
-  listEmployees,
-  getSummary,
+  closeDatabase,
   createEmployee,
-  updateEmployee,
+  databasePath,
   deleteEmployee,
   employeeExists,
+  getSummary,
+  listEmployees,
+  updateEmployee,
 };

--- a/src/public/styles.css
+++ b/src/public/styles.css
@@ -11,6 +11,9 @@
   --accent-strong: #1f2937;
   --success-bg: #eef2f7;
   --success-text: #334155;
+  --warning-bg: #fff7ed;
+  --warning-border: #fdba74;
+  --warning-text: #9a3412;
   --danger: #8b1e3f;
   --shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
   --radius: 18px;
@@ -160,6 +163,10 @@ small,
   margin-bottom: 20px;
 }
 
+.panel-heading-tight {
+  margin-bottom: 18px;
+}
+
 .sticky-panel {
   position: sticky;
   top: 24px;
@@ -242,6 +249,21 @@ tbody tr:last-child td {
   padding: 0 24px 24px;
 }
 
+.employee-form-sidebar {
+  padding: 0;
+}
+
+.filter-form {
+  display: grid;
+  gap: 18px;
+}
+
+.filter-grid {
+  display: grid;
+  grid-template-columns: 2fr repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
 .form-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -283,11 +305,17 @@ select:focus {
   grid-column: 1 / -1;
 }
 
-.form-actions {
+.form-actions,
+.filter-actions {
   display: flex;
   justify-content: flex-start;
   gap: 12px;
   margin-top: 18px;
+}
+
+.filter-actions {
+  margin-top: 0;
+  flex-wrap: wrap;
 }
 
 .button {
@@ -300,11 +328,18 @@ select:focus {
   padding: 0 18px;
   font-weight: 700;
   cursor: pointer;
+  text-decoration: none;
 }
 
 .button-primary {
   background: var(--accent-strong);
   color: #fff;
+}
+
+.button-secondary {
+  background: #fff;
+  color: var(--accent-strong);
+  border: 1px solid var(--border-strong);
 }
 
 .button-danger {
@@ -321,6 +356,82 @@ select:focus {
   padding: 0 24px 24px;
 }
 
+.filter-summary {
+  display: grid;
+  gap: 16px;
+}
+
+.validation-banner {
+  border: 1px solid var(--warning-border);
+  background: var(--warning-bg);
+  color: var(--warning-text);
+  border-radius: 16px;
+  padding: 14px 16px;
+  font-weight: 600;
+}
+
+.active-filters {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--panel-muted);
+}
+
+.filter-summary-copy {
+  margin-bottom: 0;
+}
+
+.filter-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.filter-chip {
+  min-width: 160px;
+  display: grid;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: #fff;
+}
+
+.filter-chip span {
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.filter-chip strong {
+  font-size: 15px;
+}
+
+.empty-state {
+  display: grid;
+  gap: 12px;
+  justify-items: flex-start;
+  padding: 28px;
+  border: 1px dashed var(--border-strong);
+  border-radius: 18px;
+  background: var(--panel-muted);
+}
+
+.empty-state h3,
+.empty-state p {
+  margin-bottom: 0;
+}
+
+.empty-state-compact {
+  margin-bottom: 16px;
+}
+
 @media (max-width: 1120px) {
   .stats-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -332,6 +443,10 @@ select:focus {
 
   .sticky-panel {
     position: static;
+  }
+
+  .filter-grid {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -354,5 +469,9 @@ select:focus {
 
   .employee-card-meta {
     align-items: flex-start;
+  }
+
+  .filter-chip {
+    width: 100%;
   }
 }

--- a/src/render.js
+++ b/src/render.js
@@ -9,7 +9,7 @@ function escapeHtml(value) {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/\"/g, '&quot;')
+    .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 }
 
@@ -28,6 +28,10 @@ function renderManagerOptions(employees, selectedManagerId = null, excludeId = n
   }
 
   return options.join('');
+}
+
+function renderReturnToInput(returnTo) {
+  return `<input type="hidden" name="returnTo" value="${escapeHtml(returnTo)}" />`;
 }
 
 function renderEmployeeRows(employees) {
@@ -51,7 +55,7 @@ function renderEmployeeRows(employees) {
     .join('');
 }
 
-function renderEmployeeCards(employees) {
+function renderEmployeeCards(employees, allEmployees, returnTo) {
   return employees
     .map(
       (employee) => `
@@ -67,6 +71,7 @@ function renderEmployeeCards(employees) {
             </div>
           </summary>
           <form method="post" action="/employees/${employee.id}/update" class="employee-form">
+            ${renderReturnToInput(returnTo)}
             <div class="form-grid">
               <label>
                 <span>Full name</span>
@@ -83,7 +88,7 @@ function renderEmployeeCards(employees) {
               <label>
                 <span>Manager</span>
                 <select name="managerId">
-                  ${renderManagerOptions(employees, employee.managerId, employee.id)}
+                  ${renderManagerOptions(allEmployees, employee.managerId, employee.id)}
                 </select>
               </label>
               <label class="full-width">
@@ -96,6 +101,7 @@ function renderEmployeeCards(employees) {
             </div>
           </form>
           <form method="post" action="/employees/${employee.id}/delete" class="delete-form">
+            ${renderReturnToInput(returnTo)}
             <button type="submit" class="button button-danger" onclick="return confirm('Remove ${escapeHtml(employee.name)} from payroll?');">
               Remove employee
             </button>
@@ -106,8 +112,131 @@ function renderEmployeeCards(employees) {
     .join('');
 }
 
-function renderDashboard({ employees, summary, message }) {
+function renderFilterSummary(filters, employees) {
+  const chips = [];
+
+  if (filters.applied.search) {
+    chips.push(`<li class="filter-chip"><span>Search</span><strong>${escapeHtml(filters.search)}</strong></li>`);
+  }
+
+  if (filters.applied.minSalary !== null) {
+    chips.push(`<li class="filter-chip"><span>Min salary</span><strong>${currencyFormatter.format(filters.applied.minSalary)}</strong></li>`);
+  }
+
+  if (filters.applied.maxSalary !== null) {
+    chips.push(`<li class="filter-chip"><span>Max salary</span><strong>${currencyFormatter.format(filters.applied.maxSalary)}</strong></li>`);
+  }
+
+  if (!chips.length && !filters.validationMessage) {
+    return '';
+  }
+
+  const resultCountLabel = employees.length === 1 ? '1 matching employee' : `${employees.length} matching employees`;
+
+  return `
+    <div class="filter-summary">
+      ${filters.validationMessage ? `<div class="validation-banner">${escapeHtml(filters.validationMessage)}</div>` : ''}
+      ${chips.length ? `
+        <div class="active-filters">
+          <div>
+            <p class="eyebrow">Active filters</p>
+            <p class="subtle filter-summary-copy">${resultCountLabel}</p>
+          </div>
+          <ul class="filter-chip-list">
+            ${chips.join('')}
+          </ul>
+        </div>
+      ` : ''}
+    </div>
+  `;
+}
+
+function renderFilterPanel(filters, employees) {
+  const clearAction = filters.hasSubmittedValues
+    ? '<a class="button button-secondary" href="/">Clear filters</a>'
+    : '';
+
+  return `
+    <section class="panel">
+      <div class="panel-heading panel-heading-tight">
+        <div>
+          <p class="eyebrow">Filters</p>
+          <h2>Refine the roster</h2>
+        </div>
+        <p class="subtle">Search by name or title and focus on a salary band for live demos.</p>
+      </div>
+      <form method="get" action="/" class="filter-form">
+        <div class="filter-grid">
+          <label>
+            <span>Search employees</span>
+            <input type="search" name="search" value="${escapeHtml(filters.search)}" placeholder="Search by name or title" />
+          </label>
+          <label>
+            <span>Minimum salary</span>
+            <input type="number" name="minSalary" min="0" step="1000" value="${escapeHtml(filters.minSalary)}" placeholder="90000" />
+          </label>
+          <label>
+            <span>Maximum salary</span>
+            <input type="number" name="maxSalary" min="0" step="1000" value="${escapeHtml(filters.maxSalary)}" placeholder="180000" />
+          </label>
+        </div>
+        <div class="filter-actions">
+          <button type="submit" class="button button-primary">Apply filters</button>
+          ${clearAction}
+        </div>
+      </form>
+      ${renderFilterSummary(filters, employees)}
+    </section>
+  `;
+}
+
+function renderRosterSection(employees, filters) {
+  if (!employees.length) {
+    return `
+      <div class="empty-state">
+        <h3>No employees match these filters.</h3>
+        <p>Try a broader search or clear the salary range to restore the full roster.</p>
+        ${filters.hasSubmittedValues ? '<a class="button button-secondary" href="/">Clear filters</a>' : ''}
+      </div>
+    `;
+  }
+
+  return `
+    <div class="table-wrap">
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Title</th>
+            <th>Salary</th>
+            <th>Manager</th>
+            <th>Home address</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${renderEmployeeRows(employees)}
+        </tbody>
+      </table>
+    </div>
+  `;
+}
+
+function renderEditorSection(employees) {
+  if (!employees.length) {
+    return `
+      <div class="empty-state empty-state-compact">
+        <h3>No matching employee records to edit.</h3>
+        <p>Update the filters above to continue managing payroll profiles.</p>
+      </div>
+    `;
+  }
+
+  return '';
+}
+
+function renderDashboard({ employees, allEmployees, summary, message, filters }) {
   const individualContributors = summary.headcount - summary.managerCount;
+  const visibleCountLabel = employees.length === 1 ? '1 employee shown' : `${employees.length} employees shown`;
 
   return `<!DOCTYPE html>
   <html lang="en">
@@ -164,7 +293,8 @@ function renderDashboard({ employees, summary, message }) {
                 <h2>New payroll profile</h2>
               </div>
             </div>
-            <form method="post" action="/employees" class="employee-form">
+            <form method="post" action="/employees" class="employee-form employee-form-sidebar">
+              ${renderReturnToInput(filters.returnTo)}
               <div class="form-grid single-column">
                 <label>
                   <span>Full name</span>
@@ -181,7 +311,7 @@ function renderDashboard({ employees, summary, message }) {
                 <label>
                   <span>Manager</span>
                   <select name="managerId">
-                    ${renderManagerOptions(employees)}
+                    ${renderManagerOptions(allEmployees)}
                   </select>
                 </label>
                 <label>
@@ -196,29 +326,16 @@ function renderDashboard({ employees, summary, message }) {
           </aside>
 
           <main class="dashboard-content">
+            ${renderFilterPanel(filters, employees)}
             <section class="panel">
               <div class="panel-heading">
                 <div>
                   <p class="eyebrow">Roster</p>
                   <h2>Employee directory</h2>
                 </div>
+                <p class="subtle">${visibleCountLabel}</p>
               </div>
-              <div class="table-wrap">
-                <table>
-                  <thead>
-                    <tr>
-                      <th>Name</th>
-                      <th>Title</th>
-                      <th>Salary</th>
-                      <th>Manager</th>
-                      <th>Home address</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    ${renderEmployeeRows(employees)}
-                  </tbody>
-                </table>
-              </div>
+              ${renderRosterSection(employees, filters)}
             </section>
 
             <section class="panel">
@@ -229,8 +346,9 @@ function renderDashboard({ employees, summary, message }) {
                 </div>
                 <p class="subtle">Expand a card to update salary, title, address, manager, or remove the employee from payroll.</p>
               </div>
+              ${renderEditorSection(employees)}
               <div class="cards-grid">
-                ${renderEmployeeCards(employees)}
+                ${renderEmployeeCards(employees, allEmployees, filters.returnTo)}
               </div>
             </section>
           </main>

--- a/src/server.js
+++ b/src/server.js
@@ -8,6 +8,11 @@ const {
   deleteEmployee,
   employeeExists,
 } = require('./db');
+const {
+  appendMessageToReturnTo,
+  parseDashboardFilters,
+  sanitizeReturnTo,
+} = require('./dashboardFilters');
 const { renderDashboard } = require('./render');
 
 const app = express();
@@ -16,8 +21,8 @@ const port = Number.parseInt(process.env.PORT || '3000', 10);
 app.use(express.urlencoded({ extended: false }));
 app.use('/static', express.static(path.join(__dirname, 'public')));
 
-function redirectWithMessage(res, message) {
-  res.redirect(`/?message=${encodeURIComponent(message)}`);
+function redirectWithMessage(res, message, returnTo = '/') {
+  res.redirect(appendMessageToReturnTo(returnTo, message));
 }
 
 function parseId(value) {
@@ -67,10 +72,12 @@ function parseEmployeeInput(body, employeeId = null) {
 
 app.get('/', (req, res) => {
   const message = typeof req.query.message === 'string' ? req.query.message : '';
-  const employees = listEmployees();
+  const filters = parseDashboardFilters(req.query);
+  const employees = listEmployees(filters.applied);
+  const allEmployees = listEmployees();
   const summary = getSummary();
 
-  res.type('html').send(renderDashboard({ employees, summary, message }));
+  res.type('html').send(renderDashboard({ employees, allEmployees, summary, message, filters }));
 });
 
 app.get('/health', (req, res) => {
@@ -81,47 +88,60 @@ app.get('/health', (req, res) => {
 });
 
 app.get('/api/employees', (req, res) => {
+  const filters = parseDashboardFilters(req.query);
+
   res.json({
-    employees: listEmployees(),
+    employees: listEmployees(filters.applied),
     summary: getSummary(),
+    filters: {
+      search: filters.search,
+      minSalary: filters.minSalary,
+      maxSalary: filters.maxSalary,
+      hasActiveFilters: filters.hasActiveFilters,
+      validationMessage: filters.validationMessage,
+    },
   });
 });
 
 app.post('/employees', (req, res) => {
+  const returnTo = sanitizeReturnTo(req.body.returnTo);
+
   try {
     const employee = parseEmployeeInput(req.body);
     createEmployee(employee);
-    redirectWithMessage(res, `${employee.name} added to payroll.`);
+    redirectWithMessage(res, `${employee.name} added to payroll.`, returnTo);
   } catch (error) {
-    redirectWithMessage(res, error.message || 'Unable to add employee.');
+    redirectWithMessage(res, error.message || 'Unable to add employee.', returnTo);
   }
 });
 
 app.post('/employees/:id/update', (req, res) => {
   const employeeId = parseId(req.params.id);
+  const returnTo = sanitizeReturnTo(req.body.returnTo);
 
   if (!employeeId || !employeeExists(employeeId)) {
-    return redirectWithMessage(res, 'Employee record could not be found.');
+    return redirectWithMessage(res, 'Employee record could not be found.', returnTo);
   }
 
   try {
     const employee = parseEmployeeInput(req.body, employeeId);
     updateEmployee(employeeId, employee);
-    return redirectWithMessage(res, `${employee.name}'s profile was updated.`);
+    return redirectWithMessage(res, `${employee.name}'s profile was updated.`, returnTo);
   } catch (error) {
-    return redirectWithMessage(res, error.message || 'Unable to update employee.');
+    return redirectWithMessage(res, error.message || 'Unable to update employee.', returnTo);
   }
 });
 
 app.post('/employees/:id/delete', (req, res) => {
   const employeeId = parseId(req.params.id);
+  const returnTo = sanitizeReturnTo(req.body.returnTo);
 
   if (!employeeId || !employeeExists(employeeId)) {
-    return redirectWithMessage(res, 'Employee record could not be found.');
+    return redirectWithMessage(res, 'Employee record could not be found.', returnTo);
   }
 
   const removedEmployee = deleteEmployee(employeeId);
-  return redirectWithMessage(res, `${removedEmployee.name} was removed from payroll.`);
+  return redirectWithMessage(res, `${removedEmployee.name} was removed from payroll.`, returnTo);
 });
 
 if (require.main === module) {

--- a/test/dashboard.test.js
+++ b/test/dashboard.test.js
@@ -1,0 +1,175 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const test = require('node:test');
+const request = require('supertest');
+
+function loadFixture(t) {
+  const tempDirectory = fs.mkdtempSync(path.join(os.tmpdir(), 'payroll-dashboard-'));
+  const dbFilePath = path.join(tempDirectory, 'payroll.sqlite');
+
+  process.env.PAYROLL_DB_PATH = dbFilePath;
+
+  const dbModulePath = require.resolve('../src/db');
+  const serverModulePath = require.resolve('../src/server');
+  delete require.cache[dbModulePath];
+  delete require.cache[serverModulePath];
+
+  const db = require('../src/db');
+  const app = require('../src/server');
+
+  t.after(() => {
+    db.closeDatabase();
+    delete process.env.PAYROLL_DB_PATH;
+    delete require.cache[dbModulePath];
+    delete require.cache[serverModulePath];
+    fs.rmSync(tempDirectory, { recursive: true, force: true });
+  });
+
+  return request(app);
+}
+
+function countVisibleEmployeeCards(html) {
+  return [...html.matchAll(/action="\/employees\/\d+\/update"/g)].length;
+}
+
+test('filters employees by matching name search', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent.get('/?search=sophia');
+
+  assert.equal(response.status, 200);
+  assert.equal(countVisibleEmployeeCards(response.text), 1);
+  assert.match(response.text, /<h3>Sophia Carter<\/h3>/);
+  assert.match(response.text, /value="sophia"/);
+});
+
+test('filters employees by matching title search', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent.get('/?search=accountant');
+
+  assert.equal(response.status, 200);
+  assert.equal(countVisibleEmployeeCards(response.text), 1);
+  assert.match(response.text, /<h3>Priya Patel<\/h3>/);
+});
+
+test('applies inclusive salary ranges', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent.get('/?minSalary=98000&maxSalary=154000');
+
+  assert.equal(response.status, 200);
+  assert.equal(countVisibleEmployeeCards(response.text), 3);
+  assert.match(response.text, /Daniel Kim/);
+  assert.match(response.text, /Elena Rodriguez/);
+  assert.match(response.text, /Priya Patel/);
+});
+
+test('shows active filters and clear action', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent.get('/?search=manager&minSalary=150000');
+
+  assert.equal(response.status, 200);
+  assert.match(response.text, /Active filters/);
+  assert.match(response.text, /Search/);
+  assert.match(response.text, /Min salary/);
+  assert.match(response.text, /Clear filters/);
+});
+
+test('ignores invalid salary input while preserving the entered value', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent.get('/?search=payroll&minSalary=abc');
+
+  assert.equal(response.status, 200);
+  assert.equal(countVisibleEmployeeCards(response.text), 1);
+  assert.match(response.text, /Salary filters must be whole numbers or left blank\./);
+  assert.match(response.text, /name="minSalary" min="0" step="1000" value="abc"/);
+});
+
+test('shows guidance when the minimum salary is greater than the maximum salary', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent.get('/?minSalary=200000&maxSalary=100000');
+
+  assert.equal(response.status, 200);
+  assert.equal(countVisibleEmployeeCards(response.text), 6);
+  assert.match(response.text, /Minimum salary cannot be greater than maximum salary\./);
+});
+
+test('renders an empty state when filters match no employees', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent.get('/?search=nonexistent');
+
+  assert.equal(response.status, 200);
+  assert.equal(countVisibleEmployeeCards(response.text), 0);
+  assert.match(response.text, /No employees match these filters\./);
+});
+
+test('filters the API employee list while keeping the full summary', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent.get('/api/employees?search=manager');
+
+  assert.equal(response.status, 200);
+  assert.equal(response.body.employees.length, 1);
+  assert.equal(response.body.employees[0].name, 'Elena Rodriguez');
+  assert.equal(response.body.summary.headcount, 6);
+});
+
+test('create flow preserves the filtered return view', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent
+    .post('/employees')
+    .type('form')
+    .send({
+      name: 'Jordan Lee',
+      title: 'Compensation Analyst',
+      salary: '86000',
+      managerId: '2',
+      homeAddress: '123 Market Street, Chicago, IL 60606',
+      returnTo: '/?search=Analyst',
+    })
+    .redirects(1);
+
+  assert.equal(response.status, 200);
+  assert.equal(countVisibleEmployeeCards(response.text), 1);
+  assert.match(response.text, /Jordan Lee added to payroll\./);
+  assert.match(response.text, /value="Analyst"/);
+  assert.match(response.text, /<h3>Jordan Lee<\/h3>/);
+});
+
+test('update flow preserves the filtered return view', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent
+    .post('/employees/5/update')
+    .type('form')
+    .send({
+      name: 'Daniel Kim',
+      title: 'Lead Payroll Specialist',
+      salary: '101000',
+      managerId: '2',
+      homeAddress: '512 Lakeshore Circle, Oak Park, IL 60302',
+      returnTo: '/?search=Payroll',
+    })
+    .redirects(1);
+
+  assert.equal(response.status, 200);
+  assert.equal(countVisibleEmployeeCards(response.text), 1);
+  assert.match(response.text, /Daniel Kim&#39;s profile was updated\./);
+  assert.match(response.text, /value="Payroll"/);
+  assert.match(response.text, /Lead Payroll Specialist/);
+});
+
+test('delete flow preserves the filtered return view', async (t) => {
+  const agent = loadFixture(t);
+  const response = await agent
+    .post('/employees/6/delete')
+    .type('form')
+    .send({
+      returnTo: '/?search=Brooks',
+    })
+    .redirects(1);
+
+  assert.equal(response.status, 200);
+  assert.equal(countVisibleEmployeeCards(response.text), 0);
+  assert.match(response.text, /Nina Brooks was removed from payroll\./);
+  assert.match(response.text, /value="Brooks"/);
+  assert.match(response.text, /No employees match these filters\./);
+});


### PR DESCRIPTION
Closes #1

## Summary
- add server-side employee search and inclusive salary range filters
- render active filter state, clear action, validation guidance, and empty results UI
- preserve filtered dashboard return context across create, update, and delete actions
- add isolated integration coverage for filters, API behavior, and CRUD continuity

## Spec files
- [.specify/specs/001-demo-add-employee-search-and-salary-range-filter/spec.md](.specify/specs/001-demo-add-employee-search-and-salary-range-filter/spec.md)
- [.specify/specs/001-demo-add-employee-search-and-salary-range-filter/plan.md](.specify/specs/001-demo-add-employee-search-and-salary-range-filter/plan.md)
- [.specify/specs/001-demo-add-employee-search-and-salary-range-filter/tasks.md](.specify/specs/001-demo-add-employee-search-and-salary-range-filter/tasks.md)

## Completed tasks
- [x] Task 1.1: Extract dashboard filter parsing and return-state helpers
- [x] Task 1.2: Establish isolated dashboard test coverage
- [x] Task 2.1: Add parameterized filter-aware employee queries
- [x] Task 2.2: Pass filtered and full-roster data through request handlers
- [x] Task 3.1: Render filter controls, active state, and empty results
- [x] Task 3.2: Style the filter experience and empty states
- [x] Task 4.1: Preserve safe filtered return behavior for CRUD actions
- [x] Task 4.2: Add regression coverage for filter behavior and CRUD continuity